### PR TITLE
Handle documentId being nullable

### DIFF
--- a/android-pdf-viewer/build.gradle
+++ b/android-pdf-viewer/build.gradle
@@ -42,7 +42,7 @@ afterEvaluate {
             release(MavenPublication) {
                 setGroupId 'com.github.VERO-Digital-Solutions'
                 setArtifactId 'AndroidPdfViewerV2'
-                version '1.0.0'
+                version '1.0.1'
                 artifact androidSourcesJar
                 artifact bundleReleaseAar
                 // Add dependencies to the POM file

--- a/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/annotation/core/pdf/PdfUtil.kt
+++ b/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/annotation/core/pdf/PdfUtil.kt
@@ -207,11 +207,11 @@ object PdfUtil {
                 val documentId: PdfString? =
                     documentationDict.getAsString(PdfName("documentId"))
 
-                if (schemaId != null && documentId != null) {
+                if (schemaId != null) {
                     documentations.add(
                         Documentation(
                             schemaId.intValue().toLong(),
-                            documentId.toString()
+                            documentId.toString().takeIf { it.isNotEmpty() }
                         )
                     )
                 }

--- a/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/annotation/core/pdf/PdfUtil.kt
+++ b/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/annotation/core/pdf/PdfUtil.kt
@@ -219,8 +219,7 @@ object PdfUtil {
         } else {
             return null
         }
-        val uniqueDocumentations = documentations.toSet()
-        return Relations(uniqueDocumentations.toList())
+        return Relations(documentations)
     }
 
     /** Map annotations to shapes,

--- a/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/annotation/core/pdf/PdfUtil.kt
+++ b/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/annotation/core/pdf/PdfUtil.kt
@@ -219,7 +219,8 @@ object PdfUtil {
         } else {
             return null
         }
-        return Relations(documentations)
+        val uniqueDocumentations = documentations.toSet()
+        return Relations(uniqueDocumentations.toList())
     }
 
     /** Map annotations to shapes,

--- a/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/annotation/core/shapes/Relations.kt
+++ b/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/annotation/core/shapes/Relations.kt
@@ -2,4 +2,4 @@ package com.github.barteksc.pdfviewer.annotation.core.shapes
 
 data class Relations(var documentation: List<Documentation> = emptyList())
 
-data class Documentation(val schemaId: Long, val documentId: String)
+data class Documentation(val schemaId: Long, val documentId: String?)


### PR DESCRIPTION
Make documentId nullable so we can attach documentation at later times. Convert the list of documentations to set so fake documentations are gone